### PR TITLE
http://tracker.ceph.com/issues/12402

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3941,7 +3941,7 @@ void OSDMonitor::get_pools_health(
       } else if (warn_threshold > 0 &&
 		 sum.num_bytes >= pool.quota_max_bytes*warn_threshold) {
         ss << "pool '" << pool_name
-           << "' has " << si_t(sum.num_bytes) << " objects"
+           << "' has " << si_t(sum.num_bytes) << " bytes"
            << " (max " << si_t(pool.quota_max_bytes) << ")";
         status = HEALTH_WARN;
       }


### PR DESCRIPTION
file:OSDMonitor.cc
function: void OSDMonitor::get_pools_health(
list<pair<health_status_t,string> >& summary,
list<pair<health_status_t,string> > *detail) const
describe:
......
} else if (crit_threshold > 0 &&
sum.num_bytes >= pool.quota_max_bytes*crit_threshold) {
ss << "pool '" << pool_name
<< "' has " << si_t(sum.num_bytes) << " bytes"
<< " (max " << si_t(pool.quota_max_bytes) << ")";
status = HEALTH_ERR;
} else if (warn_threshold > 0 &&
sum.num_bytes >= pool.quota_max_bytes*warn_threshold) {
ss << "pool '" << pool_name
<< "' has " << si_t(sum.num_bytes) << " objects"
<< " (max " << si_t(pool.quota_max_bytes) << ")";
status = HEALTH_WARN;
}
......

the "objects" replaced by "bytes"